### PR TITLE
Fix engine mismatch during yarn install

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+ignore-engines true


### PR DESCRIPTION
## Summary
- allow Yarn to install packages that don't support the current Node version

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68474edfa56c8325b230c19151f28b93